### PR TITLE
Avoid prerelease when using version:ci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12953,10 +12953,10 @@
     },
     "packages/eslint-config-angular": {
       "name": "@yoo-digital/eslint-config-angular",
-      "version": "14.0.1-canary.1",
+      "version": "14.0.1-canary.2",
       "license": "MIT",
       "dependencies": {
-        "@yoo-digital/eslint-config-base": "1.2.1-canary.1"
+        "@yoo-digital/eslint-config-base": "1.2.1-canary.2"
       },
       "engines": {
         "node": ">= 16",
@@ -12979,7 +12979,7 @@
     },
     "packages/eslint-config-base": {
       "name": "@yoo-digital/eslint-config-base",
-      "version": "1.2.1-canary.1",
+      "version": "1.2.1-canary.2",
       "license": "MIT",
       "dependencies": {
         "eslint-config-airbnb-base": "^15.0.0"
@@ -12998,10 +12998,10 @@
     },
     "packages/eslint-config-react": {
       "name": "@yoo-digital/eslint-config-react",
-      "version": "1.2.1-canary.1",
+      "version": "1.2.1-canary.2",
       "license": "MIT",
       "dependencies": {
-        "@yoo-digital/eslint-config-base": "1.2.1-canary.1",
+        "@yoo-digital/eslint-config-base": "1.2.1-canary.2",
         "eslint-config-airbnb": "^19.0.4"
       },
       "engines": {
@@ -16054,7 +16054,7 @@
     "@yoo-digital/eslint-config-angular": {
       "version": "file:packages/eslint-config-angular",
       "requires": {
-        "@yoo-digital/eslint-config-base": "1.2.1-canary.1"
+        "@yoo-digital/eslint-config-base": "1.2.1-canary.2"
       }
     },
     "@yoo-digital/eslint-config-base": {
@@ -16066,7 +16066,7 @@
     "@yoo-digital/eslint-config-react": {
       "version": "file:packages/eslint-config-react",
       "requires": {
-        "@yoo-digital/eslint-config-base": "1.2.1-canary.1",
+        "@yoo-digital/eslint-config-base": "1.2.1-canary.2",
         "eslint-config-airbnb": "^19.0.4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "publish:ci": "lerna publish from-package --yes",
     "publish:ci:canary": "lerna publish from-package --yes",
     "publish:manual": "lerna publish",
-    "version:ci": "lerna version --exact --conventional-commits --conventional-graduate",
+    "version:ci": "lerna version --exact --conventional-commits --conventional-graduate --yes",
     "version:ci:canary": "lerna version --exact --conventional-commits --conventional-prerelease --preid canary --yes",
     "version:manual": "lerna version"
   },

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "publish:ci": "lerna publish from-package --yes",
     "publish:ci:canary": "lerna publish from-package --yes",
     "publish:manual": "lerna publish",
-    "version:ci": "lerna version --exact --conventional-commits --yes",
+    "version:ci": "lerna version --exact --conventional-commits --conventional-graduate",
     "version:ci:canary": "lerna version --exact --conventional-commits --conventional-prerelease --preid canary --yes",
     "version:manual": "lerna version"
   },

--- a/packages/eslint-config-angular/CHANGELOG.md
+++ b/packages/eslint-config-angular/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 14.0.1-canary.2 (2023-05-08)
+
+**Note:** Version bump only for package @yoo-digital/eslint-config-angular
+
+
+
+
+
 ## 14.0.1-canary.1 (2023-05-08)
 
 **Note:** Version bump only for package @yoo-digital/eslint-config-angular

--- a/packages/eslint-config-angular/package.json
+++ b/packages/eslint-config-angular/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yoo-digital/eslint-config-angular",
   "description": "ESLint configuration file containing rules for Angular projects using TypeScript",
-  "version": "14.0.1-canary.1",
+  "version": "14.0.1-canary.2",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -82,7 +82,7 @@
     "npm": ">= 8"
   },
   "dependencies": {
-    "@yoo-digital/eslint-config-base": "1.2.1-canary.1"
+    "@yoo-digital/eslint-config-base": "1.2.1-canary.2"
   },
   "peerDependencies": {
     "@angular-eslint/builder": "^14.4.0",

--- a/packages/eslint-config-base/CHANGELOG.md
+++ b/packages/eslint-config-base/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.2.1-canary.2 (2023-05-08)
+
+**Note:** Version bump only for package @yoo-digital/eslint-config-base
+
+
+
+
+
 ## 1.2.1-canary.1 (2023-05-08)
 
 **Note:** Version bump only for package @yoo-digital/eslint-config-base

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yoo-digital/eslint-config-base",
   "description": "ESLint configuration file containing rules for TypeScript projects",
-  "version": "1.2.1-canary.1",
+  "version": "1.2.1-canary.2",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/eslint-config-react/CHANGELOG.md
+++ b/packages/eslint-config-react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.2.1-canary.2 (2023-05-08)
+
+**Note:** Version bump only for package @yoo-digital/eslint-config-react
+
+
+
+
+
 ## 1.2.1-canary.1 (2023-05-08)
 
 **Note:** Version bump only for package @yoo-digital/eslint-config-react

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yoo-digital/eslint-config-react",
   "description": "ESLint configuration file containing rules for React projects using TypeScript",
-  "version": "1.2.1-canary.1",
+  "version": "1.2.1-canary.2",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -82,7 +82,7 @@
     "npm": ">= 8"
   },
   "dependencies": {
-    "@yoo-digital/eslint-config-base": "1.2.1-canary.1",
+    "@yoo-digital/eslint-config-base": "1.2.1-canary.2",
     "eslint-config-airbnb": "^19.0.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
use `--conventional-graduate` flag to avoid prereleases