### PR TITLE
fix(eslint): Turn off overridden rule and extend missing override

### DIFF
--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -34,7 +34,14 @@ module.exports =  {
         'default': 'array'
       }
     ],
-    '@typescript-eslint/explicit-member-accessibility': 'error',
+    '@typescript-eslint/explicit-member-accessibility': [
+      'error',
+      {
+        overrides: {
+          constructors: 'no-public'
+        }
+      }
+    ],
     '@typescript-eslint/explicit-function-return-type': [
       'error',
       {
@@ -158,6 +165,10 @@ module.exports =  {
 
     // note you must disable the base rule as it can report incorrect errors
     'no-unused-vars': 'off',
+
+    // note you must disable the base rule as it can report incorrect errors
+    '@typescript-eslint/no-unused-vars': 'off',
+
     'unused-imports/no-unused-imports': 'error',
     'unused-imports/no-unused-vars': [
       'warn',


### PR DESCRIPTION
* `@typescript-eslint/no-unused-vars` needs to be turned off in order to resolve a conflict with `unused-imports/no-unused-vars`.
* `@typescript-eslint/explicit-member-accessibility` was extended to allow constructors without the public modifier, which is especially useful in Angular projects.